### PR TITLE
Red color for illegal roll context

### DIFF
--- a/disc/roll.go
+++ b/disc/roll.go
@@ -51,7 +51,7 @@ func roll(data *disgord.MessageCreate) {
 				Embed: &disgord.Embed{
 					Title:       "Illegal roll",
 					Description: fmt.Sprintf("You can roll in %s", ableToRoll.Sub(time.Now())),
-					Color:       0x225577,
+					Color:       0xcc0000,
 				}})
 	}
 }


### PR DESCRIPTION
Suggest the use of red color when context "cheh" is spawned.