### PR TITLE
Add the ability to see the 10 Trending Animes from Anilist

### DIFF
--- a/disc/help.go
+++ b/disc/help.go
@@ -16,6 +16,7 @@ func help(data *disgord.MessageCreate) {
 				profile (p) : Display profile information for yourself, or the user mentioned
 				favourite (f) : Set a favourite waifu to appear on your profile, you may choose any character you want
 				invite : Invite link to add the bot to your server
+				trendinganime (ta) : Displays the top 10 trending animes from Anilist.
 				help (h) : Display this help page
 				`,
 				Color: 0xeec400,

--- a/disc/logicDiscord.go
+++ b/disc/logicDiscord.go
@@ -79,6 +79,8 @@ func reply(s disgord.Session, data *disgord.MessageCreate) {
 		roll(data)
 	case command == "list" || command == "l":
 		list(data, args)
+	case command == "trendinganimes" || command == "ta":
+		trending(data)
 	case command == "invite":
 		invite(data)
 	default:

--- a/disc/logicDiscord.go
+++ b/disc/logicDiscord.go
@@ -80,7 +80,7 @@ func reply(s disgord.Session, data *disgord.MessageCreate) {
 	case command == "list" || command == "l":
 		list(data, args)
 	case command == "trendinganimes" || command == "ta":
-		trending(data)
+		animelist(data, args)
 	case command == "invite":
 		invite(data)
 	default:

--- a/disc/trending.go
+++ b/disc/trending.go
@@ -1,0 +1,42 @@
+package disc
+
+import (
+	"bot/database"
+  "bot/query"
+	"fmt"
+	"strconv"
+
+	"github.com/andersfylling/disgord"
+)
+
+func list(data *disgord.MessageCreate, args []string) {
+	var desc string
+	var page, i int
+	var err error
+
+	// check if there is a page input
+	if len(args) > 0 {
+		page, err = strconv.Atoi(args[0])
+		if page > 1 {
+			page--
+		}
+		if err != nil {
+			fmt.Println(err)
+		}
+	}
+
+	// Check if the list is empty, if not, return a formatted description
+	for i = 10 * page; i < 10; i++ {
+			desc += fmt.Sprintf("`%d` : %s\n", Page.Media[i].ID, Page.Media[i].UserPreferred)
+		}
+
+	// Send the message
+	client.CreateMessage(
+		ctx,
+		data.Message.ChannelID,
+		&disgord.CreateMessageParams{
+			Embed: &disgord.Embed{
+				Title:       fmt.Sprintf("Trending Anime List"),
+				Color:       0x88ffcc,
+			}})
+}

--- a/disc/trending.go
+++ b/disc/trending.go
@@ -1,21 +1,20 @@
 package disc
 
 import (
+	"bot/query"
 	"fmt"
 	"strconv"
-	"bot/query"
 
 	"github.com/andersfylling/disgord"
 )
 
 func animelist(data *disgord.MessageCreate, args []string) {
 	var desc string
-	var page, i int
-	var err error
+	var page int
 
 	// check if there is a page input
 	if len(args) > 0 {
-		page, err = strconv.Atoi(args[0])
+		page, err := strconv.Atoi(args[0])
 		if page > 1 {
 			page--
 		}
@@ -24,10 +23,14 @@ func animelist(data *disgord.MessageCreate, args []string) {
 		}
 	}
 
+	res, err := query.TrendingSearch(args)
+	if err != nil {
+		fmt.Println(err)
+	}
 	// Check if the list is empty, if not, return a formatted description
-	for i = 10 * page; i < 10; i++ {
-			desc += fmt.Sprintf("`%d` : %s\n", Media[i].ID, Media[i].UserPreferred)
-		}
+	for i := 10 * page; i < 10; i++ {
+		desc += fmt.Sprintf("`%d` : %s\n", res.Media.ID, res.Media.Title.UserPreferred)
+	}
 
 	// Send the message
 	client.CreateMessage(
@@ -35,7 +38,7 @@ func animelist(data *disgord.MessageCreate, args []string) {
 		data.Message.ChannelID,
 		&disgord.CreateMessageParams{
 			Embed: &disgord.Embed{
-				Title:       fmt.Sprintf("Trending Anime List"),
-				Color:       0x88ffcc,
+				Title: fmt.Sprintf("Trending Anime List"),
+				Color: 0x88ffcc,
 			}})
 }

--- a/disc/trending.go
+++ b/disc/trending.go
@@ -39,6 +39,7 @@ func animelist(data *disgord.MessageCreate, args []string) {
 		&disgord.CreateMessageParams{
 			Embed: &disgord.Embed{
 				Title: fmt.Sprintf("Trending Anime List"),
+				Description : desc,
 				Color: 0x88ffcc,
 			}})
 }

--- a/disc/trending.go
+++ b/disc/trending.go
@@ -1,15 +1,14 @@
 package disc
 
 import (
-	"bot/database"
-  "bot/query"
 	"fmt"
 	"strconv"
+	"bot/query"
 
 	"github.com/andersfylling/disgord"
 )
 
-func list(data *disgord.MessageCreate, args []string) {
+func animelist(data *disgord.MessageCreate, args []string) {
 	var desc string
 	var page, i int
 	var err error
@@ -27,7 +26,7 @@ func list(data *disgord.MessageCreate, args []string) {
 
 	// Check if the list is empty, if not, return a formatted description
 	for i = 10 * page; i < 10; i++ {
-			desc += fmt.Sprintf("`%d` : %s\n", Page.Media[i].ID, Page.Media[i].UserPreferred)
+			desc += fmt.Sprintf("`%d` : %s\n", Media[i].ID, Media[i].UserPreferred)
 		}
 
 	// Send the message

--- a/query/tvTrendingSearch.go
+++ b/query/tvTrendingSearch.go
@@ -2,13 +2,11 @@ package query
 
 import (
 	"context"
-	"strconv"
-	"strings"
 
 	"github.com/machinebox/graphql"
 )
 
-// CharSearchStruct handles data from CharByName queries
+// tvTrendingStruct handles data from the queries.
 type tvTrendingStruct struct {
 	Media struct {
 		ID      int    `json:"id"`
@@ -20,13 +18,12 @@ type tvTrendingStruct struct {
 			Large string `json:"large"`
 		}
 		AverageScore  int `json:"averageScore"`
-    Popularity    int   `json:"popularity"`
-		}
+    		Popularity    int `json:"popularity"`
 	}
 }
 
 // TrendingSearch makes a query to the AniList GraphQL API to scrape the 10 best trending animes right now.
-func TrendingSearch(args []string) (CharSearchStruct, error) {
+func TrendingSearch(args []string) (tvTrendingStruct, error) {
 	var res tvTrendingStruct
 
 	// build query
@@ -51,13 +48,14 @@ func TrendingSearch(args []string) (CharSearchStruct, error) {
 }
 	`)
 	// Inject pre-made vars to get the trending animes.
-  req.Var("page", 1)
-  req.Var("type", "ANIME")
-  req.Var("sort", "["TRENDING_DESC","POPULARITY_DESC"]")
+  	req.Var("page", 1)
+  	req.Var("type", "ANIME")
+  	req.Var("sort", "TRENDING_DESC")
+  	req.Var("sort", "POPULARITY_DESC")
 
-  // Execute code
+  	// Execute code
 	ctx := context.Background()
-	err = client.Run(ctx, req, &res)
-
+	err := client.Run(ctx, req, &res)
+	
 	return res, err
 }

--- a/query/tvTrendingSearch.go
+++ b/query/tvTrendingSearch.go
@@ -1,0 +1,63 @@
+package query
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/machinebox/graphql"
+)
+
+// CharSearchStruct handles data from CharByName queries
+type tvTrendingStruct struct {
+	Media struct {
+		ID      int    `json:"id"`
+		SiteURL string `json:"siteUrl"`
+		Title    struct {
+			UserPreferred string `json:"userPreferred"`
+		}
+		CoverImage struct {
+			Large string `json:"large"`
+		}
+		AverageScore  int `json:"averageScore"`
+    Popularity    int   `json:"popularity"`
+		}
+	}
+}
+
+// TrendingSearch makes a query to the AniList GraphQL API to scrape the 10 best trending animes right now.
+func TrendingSearch(args []string) (CharSearchStruct, error) {
+	var res tvTrendingStruct
+
+	// build query
+	graphURL := "https://graphql.anilist.co"
+	client := graphql.NewClient(graphURL)
+	req := graphql.NewRequest(`
+	query ($page: Int, $type: MediaType, $sort: [MediaSort]) {
+  Page(perPage: 10, page: $page) {
+    media(type: $type, sort: $sort) {
+      id
+      siteUrl
+      title {
+        userPreferred
+      }
+      coverImage {
+        large
+      }
+      averageScore
+      popularity
+    }
+  }
+}
+	`)
+	// Inject pre-made vars to get the trending animes.
+  req.Var("page", 1)
+  req.Var("type", "ANIME")
+  req.Var("sort", "["TRENDING_DESC","POPULARITY_DESC"]")
+
+  // Execute code
+	ctx := context.Background()
+	err = client.Run(ctx, req, &res)
+
+	return res, err
+}


### PR DESCRIPTION
This permits the user to actually see which anime is trending right now.

- Sends a GraphQL query to Anilist's API to scrape the 10 best animes
- Disgord gathers the data and shows them to the final users in a list with "Top 10 Trending Animes".

EDIT : Everything is in a working state.