### PR TITLE
Implement Anime searching from Anilist

### DIFF
--- a/disc/animesearch.go
+++ b/disc/animesearch.go
@@ -1,0 +1,40 @@
+package disc
+
+import (
+	"bot/query"
+	"fmt"
+
+	"github.com/andersfylling/disgord"
+)
+
+func animesearch(data *disgord.MessageCreate, args []string) {
+	// check if there is a search term
+	if len(args) > 0 {
+		resp, err := query.CharSearch(args)
+		if err == nil {
+			desc := fmt.Sprintf("I found the anime ID : %d\nThe name of the anime is : %s\n", resp.Anime.ID, resp.Anime.Title.Romaji)
+			client.CreateMessage(
+				ctx,
+				data.Message.ChannelID,
+				&disgord.CreateMessageParams{
+					Embed: &disgord.Embed{
+						Title:       resp.Anime.Name.Full,
+						URL:         resp.Anime.SiteURL,
+						Description: desc,
+						Color:       0x225577,
+						Image: &disgord.EmbedImage{
+							URL: resp.Anime.Image.Large,
+						},
+					}})
+		} else {
+			client.SendMsg(ctx, data.Message.ChannelID, err)
+		}
+	} else {
+		client.CreateMessage(
+			ctx,
+			data.Message.ChannelID,
+			&disgord.CreateMessageParams{
+				Embed: &disgord.Embed{Title: "Error, search requires at least 1 argument", Color: 0xcc0000}})
+	}
+
+}

--- a/disc/animesearch.go
+++ b/disc/animesearch.go
@@ -3,6 +3,7 @@ package disc
 import (
 	"bot/query"
 	"fmt"
+	"strings"
 
 	"github.com/andersfylling/disgord"
 )
@@ -12,7 +13,17 @@ func animesearch(data *disgord.MessageCreate, args []string) {
 	if len(args) > 0 {
 		resp, err := query.CharSearch(args)
 		if err == nil {
-			desc := fmt.Sprintf("I found the anime ID : %d\nThe name of the anime is : %s\n", resp.Anime.ID, resp.Anime.Title.Romaji)
+			desc := fmt.Sprintf("I found the anime ID %d.\n " +
+				"The name of the anime is %s.\n " +
+				"Description : %s.\n " +
+				"This anime is %s. \n" +
+				"Number of episodes : %d.\n" +
+				"Adult anime (hentai/ecchi) : %s", resp.Anime.ID,
+				resp.Anime.Title.Romaji,
+				resp.Anime.Description,
+				strings.ToLower(resp.Anime.Status),
+				resp.Anime.Episodes,
+				resp.Anime.IsAdult)
 			client.CreateMessage(
 				ctx,
 				data.Message.ChannelID,

--- a/disc/animesearch.go
+++ b/disc/animesearch.go
@@ -16,7 +16,7 @@ func animesearch(data *disgord.MessageCreate, args []string) {
 			desc := fmt.Sprintf("I found the anime ID %d.\n " +
 				"The name of the anime is %s.\n " +
 				"Description : %s.\n " +
-				"This anime is %s. \n" +
+				"This anime is %s.\n" +
 				"Number of episodes : %d.\n" +
 				"Adult anime (hentai/ecchi) : %s", resp.Anime.ID,
 				resp.Anime.Title.Romaji,

--- a/disc/logicDiscord.go
+++ b/disc/logicDiscord.go
@@ -80,7 +80,7 @@ func reply(s disgord.Session, data *disgord.MessageCreate) {
 	case command == "list" || command == "l":
 		list(data, args)
 	case command == "trendinganimes" || command == "ta":
-		trending(data)
+		animelist(data, args)
 	case command == "invite":
 		invite(data)
 	default:

--- a/disc/logicDiscord.go
+++ b/disc/logicDiscord.go
@@ -67,6 +67,8 @@ func reply(s disgord.Session, data *disgord.MessageCreate) {
 
 	// Check if it recognises the command, if it doesn't, send back an error message
 	switch {
+	case command == "anime" || command == "a":
+		animesearch(data, args)
 	case command == "search" || command == "s":
 		search(data, args)
 	case command == "favourite" || command == "favorite" || command == "f":

--- a/disc/trending.go
+++ b/disc/trending.go
@@ -1,21 +1,20 @@
 package disc
 
 import (
+	"bot/query"
 	"fmt"
 	"strconv"
-	"bot/query"
 
 	"github.com/andersfylling/disgord"
 )
 
 func animelist(data *disgord.MessageCreate, args []string) {
 	var desc string
-	var page, i int
-	var err error
+	var page int
 
 	// check if there is a page input
 	if len(args) > 0 {
-		page, err = strconv.Atoi(args[0])
+		page, err := strconv.Atoi(args[0])
 		if page > 1 {
 			page--
 		}
@@ -24,10 +23,14 @@ func animelist(data *disgord.MessageCreate, args []string) {
 		}
 	}
 
+	res, err := query.TrendingSearch(args)
+	if err != nil {
+		fmt.Println(err)
+	}
 	// Check if the list is empty, if not, return a formatted description
-	for i = 10 * page; i < 10; i++ {
-			desc += fmt.Sprintf("`%d` : %s\n", Media[i].ID, Media[i].UserPreferred)
-		}
+	for i := 10 * page; i < 10; i++ {
+		desc += fmt.Sprintf("`%d` : %s\n", res.Media.ID, res.Media.Title.UserPreferred)
+	}
 
 	// Send the message
 	client.CreateMessage(
@@ -35,7 +38,7 @@ func animelist(data *disgord.MessageCreate, args []string) {
 		data.Message.ChannelID,
 		&disgord.CreateMessageParams{
 			Embed: &disgord.Embed{
-				Title:       fmt.Sprintf("Trending Anime List"),
-				Color:       0x88ffcc,
+				Title: fmt.Sprintf("Trending Anime List"),
+				Color: 0x88ffcc,
 			}})
 }

--- a/disc/trending.go
+++ b/disc/trending.go
@@ -39,6 +39,7 @@ func animelist(data *disgord.MessageCreate, args []string) {
 		&disgord.CreateMessageParams{
 			Embed: &disgord.Embed{
 				Title: fmt.Sprintf("Trending Anime List"),
+				Description : desc,
 				Color: 0x88ffcc,
 			}})
 }

--- a/disc/trending.go
+++ b/disc/trending.go
@@ -39,7 +39,6 @@ func animelist(data *disgord.MessageCreate, args []string) {
 		&disgord.CreateMessageParams{
 			Embed: &disgord.Embed{
 				Title: fmt.Sprintf("Trending Anime List"),
-				Description : desc,
 				Color: 0x88ffcc,
 			}})
 }

--- a/query/animSearch.go
+++ b/query/animSearch.go
@@ -1,0 +1,73 @@
+package query
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/machinebox/graphql"
+)
+
+// AnimSearchStruct handles data from CharByName queries
+type AnimSearchStruct struct {
+	Anime struct {
+		ID      int    `json:"id"`
+		SiteURL string `json:"siteUrl"`
+		Title    struct {
+			Romaji string `json:"romaji"`
+		}
+		CoverImage struct {
+			Large string `json:"large"`
+		}
+		Status	    string `json:"status"`
+		Episodes    string `json:"episodes"`
+		Description string `json:"description"`
+		AverageScore string `json:"averageScore"`
+		IsAdult	     string `json:"isAdult"`
+	}
+}
+
+// AnimSearch makes a query to the anilist API based on the name//ID you input
+func AnimSearch(args []string) (CharSearchStruct, error) {
+	var res AnimSearchStruct
+
+	// build query
+	graphURL := "https://graphql.anilist.co"
+	client := graphql.NewClient(graphURL)
+	req := graphql.NewRequest(`
+	query ($query: String, $type: MediaType) {
+  Page (perPage: 1) {
+    media(search: $query, type: $type) {
+      id
+      title {
+        romaji
+      }
+      coverImage {
+        large
+      }
+      status
+      episodes
+      description
+      averageScore
+      isAdult
+    }
+  }
+}
+	`)
+	// Parse the arguments to check if an ID or a Name was entered
+	req.Var("type", "ANIME")
+	arg := strings.Join(args, " ")
+	id, err := strconv.Atoi(arg)
+
+	// Add variable
+	if id != 0 {
+		req.Var("id", id)
+	} else {
+		req.Var("query", arg)
+	}
+
+	ctx := context.Background()
+	err = client.Run(ctx, req, &res)
+
+	return res, err
+}

--- a/query/animSearch.go
+++ b/query/animSearch.go
@@ -28,7 +28,7 @@ type AnimSearchStruct struct {
 }
 
 // AnimSearch makes a query to the anilist API based on the name//ID you input
-func AnimSearch(args []string) (CharSearchStruct, error) {
+func AnimSearch(args []string) (AnimSearchStruct, error) {
 	var res AnimSearchStruct
 
 	// build query


### PR DESCRIPTION
On the same essence as the Trending Anime list, this PR permits WaifuBot to search an specific anime.

- Sends query to Anilist to get the anime, depending on the ID or on a name.
- Disgord gets the data and uses it.