### PR TITLE
Added ToLower to command parser to accept uppercase command aliases

### DIFF
--- a/discord/main.go
+++ b/discord/main.go
@@ -59,6 +59,7 @@ func BotRun(cf config.ConfJSONStruct) {
 
 func reply(s disgord.Session, data *disgord.MessageCreate) {
 	cmd, args := ParseMessage(data)
+	cmd = strings.ToLower(cmd)
 
 	// Check if it recognises the command, if not, send back an error message
 	switch {


### PR DESCRIPTION
Added as a simple fix for #2 

I think this is a little cleaner than adding more aliases, as it works for both the full command name and the alias in the case of autocorrecting a letter to uppercase.