### PR TITLE
bot: add holders command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A Discord bot for collecting and trading anime/manga characters. Roll for random
 - **claim**: claim a dropped character
 - **exchange**: exchange a character for a token
 - **give**: give a character to someone
+- **holders**: list users in this server who have a character
 - **info**: information about the bot
 - **list**: view character collection
 - **roll**: roll a random character

--- a/backend/db/characters/queries.sql
+++ b/backend/db/characters/queries.sql
@@ -43,6 +43,16 @@ WHERE
   id = $1
   AND characters.user_id = $2;
 
+-- name: GetByID :one
+SELECT
+    *
+FROM
+    characters
+WHERE
+    id = $1
+LIMIT
+    1;
+
 -- name: Insert :exec
 INSERT INTO
   characters ("id", "user_id", "image", "name", "type")
@@ -102,3 +112,13 @@ ORDER BY
   date DESC
 LIMIT
   sqlc.arg (lim);
+    *;
+
+-- name: UsersOwningCharFiltered :many
+SELECT DISTINCT
+    user_id
+FROM
+    characters
+WHERE
+    id = $1
+    AND user_id = ANY (sqlc.arg(user_ids)::bigint[]);

--- a/backend/discord/commands.go
+++ b/backend/discord/commands.go
@@ -59,6 +59,10 @@ func (b *Bot) RegisterCommands() error {
 		),
 
 		corde.NewSlashCommand("info", "information about the bot"),
+
+		corde.NewSlashCommand("holders", "list users in this server who have a character",
+			corde.NewIntOption("id", "id of the character", true).CanAutocomplete(),
+		),
 	}
 
 	var opt []func(*corde.CommandsOpt)

--- a/backend/discord/discord.go
+++ b/backend/discord/discord.go
@@ -18,6 +18,7 @@ type Store interface {
 	PutChar(context.Context, corde.Snowflake, Character) error
 	Chars(context.Context, corde.Snowflake) ([]Character, error)
 	VerifyChar(context.Context, corde.Snowflake, int64) (Character, error)
+	GetCharByID(context.Context, int64) (Character, error)
 	CharsIDs(ctx context.Context, userID corde.Snowflake) ([]int64, error)
 	DeleteChar(context.Context, corde.Snowflake, int64) (Character, error)
 	CharsStartingWith(context.Context, corde.Snowflake, string) ([]Character, error)
@@ -31,6 +32,7 @@ type Store interface {
 	GiveUserChar(ctx context.Context, dst, src corde.Snowflake, charID int64) error
 	AddDropToken(context.Context, corde.Snowflake) error
 	ConsumeDropTokens(context.Context, corde.Snowflake, int32) (User, error)
+	UsersOwningCharFiltered(ctx context.Context, charID int64, allowedUserIDs []corde.Snowflake) ([]corde.Snowflake, error)
 	Tx(ctx context.Context, fn func(s Store) error) error
 }
 
@@ -82,6 +84,7 @@ func New(b *Bot) *corde.Mux {
 	b.mux.Route("profile", b.profile)
 	b.mux.Route("verify", b.verify)
 	b.mux.Route("exchange", b.exchange)
+	b.mux.Route("holders", b.holders)
 	b.mux.SlashCommand("list", wrap(b.list, t, i))
 	b.mux.SlashCommand("roll", wrap(b.roll, t, i))
 	b.mux.SlashCommand("info", wrap(b.info, t))

--- a/backend/discord/holders.go
+++ b/backend/discord/holders.go
@@ -1,0 +1,124 @@
+package discord
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Karitham/corde"
+)
+
+func (b *Bot) holders(m *corde.Mux) {
+	m.SlashCommand("", wrap(
+		b.holdersCommand,
+		trace[corde.SlashCommandInteractionData],
+		interact(b.Inter, onInteraction[corde.SlashCommandInteractionData](b)),
+	))
+	m.Autocomplete("id", b.verifyAutocomplete)
+}
+
+func (b *Bot) holdersCommand(ctx context.Context, w corde.ResponseWriter, i *corde.Interaction[corde.SlashCommandInteractionData]) {
+	charID, errCharOK := i.Data.Options.Int("id")
+	if errCharOK != nil {
+		w.Respond(rspErr("select a character to check"))
+		return
+	}
+
+	if i.GuildID == 0 {
+		w.Respond(rspErr("this command can only be used in servers"))
+		return
+	}
+
+	char, err := b.Store.GetCharByID(ctx, int64(charID))
+	if err != nil {
+		w.Respond(newErrf("no one in this server has %d", charID))
+		return
+	}
+
+	memberIDs, err := fetchGuildMemberIDs(ctx, b.BotToken, i.GuildID)
+	if err != nil {
+		w.Respond(newErrf("failed to fetch guild members: %v", err))
+		return
+	}
+
+	holderIDs, err := b.Store.UsersOwningCharFiltered(ctx, int64(charID), memberIDs)
+	if err != nil {
+		w.Respond(newErrf("failed to fetch character holders: %v", err))
+		return
+	}
+
+	if len(holderIDs) == 0 {
+		w.Respond(corde.NewResp().Contentf("No one in this server has **%s** (ID: %d)", char.Name, charID).Ephemeral())
+		return
+	}
+
+	var mentions strings.Builder
+
+	mentions.WriteString(fmt.Sprintf("Users in this server who have **%s** (ID: %d):\n", char.Name, charID))
+	for _, holderID := range holderIDs {
+		mentions.WriteString(fmt.Sprintf("- <@%d>\n", holderID))
+	}
+
+	w.Respond(corde.NewResp().Content(mentions.String()).Ephemeral())
+}
+
+func fetchGuildMemberIDs(ctx context.Context, botToken string, guildID corde.Snowflake) ([]corde.Snowflake, error) {
+	var allMemberIDs []corde.Snowflake
+
+	after := corde.Snowflake(0)
+
+	for {
+		members, err := fetchGuildMembersPage(ctx, botToken, guildID, after)
+		if err != nil {
+			return nil, err
+		}
+
+		if len(members) == 0 {
+			break
+		}
+
+		for _, member := range members {
+			allMemberIDs = append(allMemberIDs, member.User.ID)
+		}
+
+		if len(members) < 1000 {
+			break
+		}
+
+		after = members[len(members)-1].User.ID
+	}
+
+	return allMemberIDs, nil
+}
+
+func fetchGuildMembersPage(ctx context.Context, botToken string, guildID, after corde.Snowflake) ([]corde.Member, error) {
+	url := fmt.Sprintf("https://discord.com/api/v10/guilds/%d/members?limit=1000", guildID)
+	if after != 0 {
+		url = fmt.Sprintf("%s&after=%d", url, after)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bot "+botToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch guild members: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch guild members: status %d", resp.StatusCode)
+	}
+
+	var members []corde.Member
+	if err := json.NewDecoder(resp.Body).Decode(&members); err != nil {
+		return nil, fmt.Errorf("failed to decode members: %w", err)
+	}
+
+	return members, nil
+}


### PR DESCRIPTION
## Summary

Adds /holders command to list server members who own a specific character, addressing the need to discover
character ownership across guilds.

## Implementation Details

- Guild-scoped operation: Fetches all guild members via Discord API and filters against character ownership
- tabase to prevent cross-guild data leakage
• Performance consideration: May be slow in large guilds (10k+ members) due to pagination through member list.
Acceptable for initial implementation
- Privileged intent requirement: Bot now requires GUILD_MEMBERS intent to access member lists

Closes #69